### PR TITLE
Return correct id in get_sierra_catalogue_id() in the case of multiple API results

### DIFF
--- a/apis/palette_api/generate_identifiers.py
+++ b/apis/palette_api/generate_identifiers.py
@@ -69,11 +69,22 @@ def get_miro_catalogue_id(miro_id):
     return miro_catalogue_id
 
 
+def choose_correct_catalogue_id(miro_id, results):
+    sierra_catalogue_id = None
+    for work in results:
+        try:
+            if miro_id in work['thumbnail']['url']:
+                sierra_catalogue_id = work['id']
+        except KeyError:
+            pass
+    return sierra_catalogue_id
+
+
 def get_sierra_catalogue_id(miro_id):
     try:
         base_url = 'https://api.wellcomecollection.org/catalogue/v2/works?query='
-        response = requests.get(base_url + miro_id).json()
-        sierra_catalogue_id = response['results'][0]['id']
+        results = requests.get(base_url + miro_id).json()['results']
+        sierra_catalogue_id = choose_correct_catalogue_id(miro_id, results)
     except:
         sierra_catalogue_id = None
     return sierra_catalogue_id


### PR DESCRIPTION
As mentioned in https://github.com/wellcometrust/platform/issues/4078#issuecomment-561102100:
>the identifiers generation script assumes that querying the catalogue API for a miro id will return only one work, but there are a few situations where this is not the case (a miro id might be mentioned in the description of another related work, for example).

We now look at the thumbnail url of each work in the set of results to determine the correct sierra_catalogue_id

`identifiers.pkl` has been updated accordingly, and the palette API should now return results for works like [p72b7vqb](https://labs.wellcomecollection.org/palette-api/works/p72b7vqb)