### PR TITLE
Use the new location of the VPC terraform state

### DIFF
--- a/terraform/apis/locals.tf
+++ b/terraform/apis/locals.tf
@@ -1,9 +1,9 @@
 locals {
   nginx_container_image          = "wellcome/nginx_api-gw:77d1ba9b060a184097a26bc685735be343b1a754"
   nginx_listener_port            = "9000"
-  public_subnets                 = "${data.terraform_remote_state.shared_infra.datascience_vpc_public_subnets}"
-  private_subnets                = "${data.terraform_remote_state.shared_infra.datascience_vpc_private_subnets}"
-  vpc_id                         = "${data.terraform_remote_state.shared_infra.datascience_vpc_id}"
+  public_subnets                 = "${data.terraform_remote_state.accounts_data.datascience_vpc_public_subnets}"
+  private_subnets                = "${data.terraform_remote_state.accounts_data.datascience_vpc_private_subnets}"
+  vpc_id                         = "${data.terraform_remote_state.accounts_data.datascience_vpc_id}"
   namespace_id                = "datascience"
   cluster_id                  = "apis"
   miro_read_role              = "arn:aws:iam::760097843905:role/sourcedata-miro-assumable_read_role"

--- a/terraform/apis/terraform.tf
+++ b/terraform/apis/terraform.tf
@@ -23,18 +23,6 @@ data "terraform_remote_state" "shared_infra" {
   }
 }
 
-data "terraform_remote_state" "datascience_data_infra" {
-  backend = "s3"
-
-  config {
-    role_arn = "arn:aws:iam::964279923020:role/data-developer"
-
-    bucket = "wellcomecollection-datascience-infra"
-    key    = "terraform/datascience_data.tfstate"
-    region = "eu-west-1"
-  }
-}
-
 provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::964279923020:role/data-admin"

--- a/terraform/apis/terraform.tf
+++ b/terraform/apis/terraform.tf
@@ -11,14 +11,14 @@ terraform {
   }
 }
 
-data "terraform_remote_state" "shared_infra" {
+data "terraform_remote_state" "accounts_data" {
   backend = "s3"
 
   config {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"
 
     bucket = "wellcomecollection-platform-infra"
-    key    = "terraform/shared_infra.tfstate"
+    key    = "terraform/accounts/data.tfstate"
     region = "eu-west-1"
   }
 }


### PR DESCRIPTION
Part of wellcomecollection/platform#4802

We've rearranged some of our Terraform configs to reduce the amount of cross-account coupling. Changing the storage VPC shouldn't affect the data science VPC, etc.

This should be a no-op, but this Terraform is pretty old and I can no longer plan/apply.