### PR TITLE
Add a function for getting a reporting client

### DIFF
--- a/weco_datascience/aws.py
+++ b/weco_datascience/aws.py
@@ -24,3 +24,27 @@ def download_object_from_s3(bucket_name, object_key, file_name=None):
         Key=object_key,
         Filename=(file_name or os.path.basename(object_key)),
     )
+
+
+def get_session(*, role_arn):
+    """
+    Returns a boto3 Session authenticated with the current role ARN.
+    """
+    sts_client = boto3.client("sts")
+    assumed_role_object = sts_client.assume_role(
+        RoleArn=role_arn, RoleSessionName="AssumeRoleSession1"
+    )
+    credentials = assumed_role_object["Credentials"]
+    return boto3.Session(
+        aws_access_key_id=credentials["AccessKeyId"],
+        aws_secret_access_key=credentials["SecretAccessKey"],
+        aws_session_token=credentials["SessionToken"],
+    )
+
+
+def get_secret_string(session, *, secret_id):
+    """
+    Look up the value of a SecretString in Secrets Manager.
+    """
+    secrets = session.client("secretsmanager")
+    return secrets.get_secret_value(SecretId=secret_id)["SecretString"]


### PR DESCRIPTION
This simplifies the process of getting a client with read-only access to the reporting cluster.  I've put some read-only credentials in Secrets Manager, and now you run:

```python
from weco_datascience.reporting import get_es_client
es = get_es_client()
```

Sharing in case you'd find this useful to have as part of the lib.