### PR TITLE
Pin the elasticsearch version in weco_datascience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ default: build
 
 # commands for building the package
 setup:
-	python -m pip install --upgrade pip
 	pip install flit
 	flit install -s
 
@@ -29,8 +28,10 @@ publish: check_version build
 
 # general commands
 clean:
-	rm -rf .hypothesis
-	rm -rf .pytest_cache
-	rm -rf ./*/__pycache__
-	rm -rf ./dist
-	rm -rf ./site
+	isort weco_datascience/**/*.py
+	black weco_datascience --line-length 80
+	flake8 weco_datascience --max-line-length 80 --ignore=E501,W291
+	rm -rf *.pyc **/*.pyc
+	rm -rf .hypothesis **/.hypothesis
+	rm -rf .pytest_cache **/.pytest_cache
+	rm -rf __pycache__ ./**/__pycache__

--- a/notebooks/analysis/requirements.in
+++ b/notebooks/analysis/requirements.in
@@ -1,2 +1,2 @@
 weco-datascience
-elasticsearch
+elasticsearch==7.12

--- a/notebooks/analysis/requirements.in
+++ b/notebooks/analysis/requirements.in
@@ -1,2 +1,2 @@
-weco-datascience
-elasticsearch==7.12
+weco-datascience==0.1.9
+elasticsearch==7.14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ requires = [
     "Pillow==7.0.0",
     "piffle==0.3.0",
     "urlpath==1.1.7",
-    "elasticsearch==7.12",
+    "elasticsearch==7.14",
 ]
 
 [tool.flit.metadata.requires-extra]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ requires = [
     "Pillow==7.0.0",
     "piffle==0.3.0",
     "urlpath==1.1.7",
+    "elasticsearch==7.12",
 ]
 
 [tool.flit.metadata.requires-extra]

--- a/weco_datascience/__init__.py
+++ b/weco_datascience/__init__.py
@@ -2,4 +2,4 @@
 Common functionality for data science applications at Wellcome Collection
 """
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"

--- a/weco_datascience/api/catalogue.py
+++ b/weco_datascience/api/catalogue.py
@@ -1,4 +1,5 @@
 import random
+
 from . import api_url
 
 catalogue_url = api_url / "works"

--- a/weco_datascience/api/image.py
+++ b/weco_datascience/api/image.py
@@ -1,4 +1,5 @@
 import random
+
 from . import api_url
 
 images_url = api_url / "images"

--- a/weco_datascience/test/test_http.py
+++ b/weco_datascience/test/test_http.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+
 from weco_datascience.http import (
     close_persistent_client_session,
     fetch_redirect_url,

--- a/weco_datascience/test/test_image.py
+++ b/weco_datascience/test/test_image.py
@@ -1,5 +1,6 @@
 import pytest
 from PIL.Image import Image
+
 from weco_datascience.http import (
     close_persistent_client_session,
     fetch_url_bytes,


### PR DESCRIPTION
- pins the version of the elasticsearch client to 7.14 in the `weco_datascience` package and the `analysis` notebooks
- cleans up some of the functionality in `weco_datascience.reporting`, especially the need to specify an `index` twice in some functions

This PR should be followed by a 0.1.9 release of the weco_datascience package