### PR TITLE
replace references to the old conversion index with the new data stream

### DIFF
--- a/notebooks/analysis/notebooks/Bernard_de_Gordon_query.ipynb
+++ b/notebooks/analysis/notebooks/Bernard_de_Gordon_query.ipynb
@@ -17,7 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = get_recent_data(config=os.environ, n=10000, index=\"conversion*\")\n",
+    "df = get_recent_data(config=os.environ, n=10000, index=\"metrics-conversion-prod\")\n",
     "df.head()"
    ]
   },

--- a/notebooks/analysis/notebooks/art_of_science_query.ipynb
+++ b/notebooks/analysis/notebooks/art_of_science_query.ipynb
@@ -23,7 +23,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = get_recent_data(config=os.environ, n=100, index=\"conversion*\")"
+    "df = get_recent_data(config=os.environ, n=100, index=\"metrics-conversion-prod\")"
    ]
   },
   {

--- a/notebooks/analysis/notebooks/breadth_metric.ipynb
+++ b/notebooks/analysis/notebooks/breadth_metric.ipynb
@@ -17,7 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = get_recent_data(config=os.environ, n=10000, index=\"conversion*\")"
+    "df = get_recent_data(config=os.environ, n=10000, index=\"metrics-conversion-prod\")"
    ]
   },
   {

--- a/notebooks/analysis/notebooks/completeness.ipynb
+++ b/notebooks/analysis/notebooks/completeness.ipynb
@@ -72,7 +72,7 @@
    "source": [
     "clicks = reporting.query_es(\n",
     "    config=os.environ,\n",
-    "    index=\"conversion*\",\n",
+    "    index=\"metrics-conversion-prod\",\n",
     "    query={\n",
     "        \"size\": 100000,\n",
     "        \"sort\": [{\"@timestamp\": {\"order\": \"desc\"}}],\n",

--- a/notebooks/analysis/notebooks/manifest_usage.ipynb
+++ b/notebooks/analysis/notebooks/manifest_usage.ipynb
@@ -17,7 +17,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = get_recent_data(config=os.environ, n=10000, index=\"conversion*\")"
+    "df = get_recent_data(config=os.environ, n=10000,\n",
+    "                     index=\"metrics-conversion-prod\")\n"
    ]
   },
   {

--- a/notebooks/analysis/notebooks/null_queries.ipynb
+++ b/notebooks/analysis/notebooks/null_queries.ipynb
@@ -17,7 +17,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = get_recent_data(config=os.environ, n=10000, index=\"conversion*\")"
+    "df = get_recent_data(config=os.environ, n=10000,\n",
+    "                     index=\"metrics-conversion-prod\")\n"
    ]
   },
   {

--- a/notebooks/analysis/notebooks/search_dupes.ipynb
+++ b/notebooks/analysis/notebooks/search_dupes.ipynb
@@ -24,7 +24,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = get_recent_data(config=os.environ, n=10000, index=\"conversion*\")"
+    "df = get_recent_data(config=os.environ, n=10000,\n",
+    "                     index=\"metrics-conversion-prod\")\n"
    ]
   },
   {

--- a/notebooks/concepts/notebooks/02 - creating a comparable dataset.ipynb
+++ b/notebooks/concepts/notebooks/02 - creating a comparable dataset.ipynb
@@ -43,10 +43,10 @@
    "source": [
     "df = get_data_in_date_range(\n",
     "    config=os.environ,\n",
-    "    index=\"conversion*\",\n",
+    "    index=\"metrics-conversion-prod\",\n",
     "    start_date=\"2021-09-01\",\n",
     "    end_date=\"2021-09-02\",\n",
-    ")"
+    ")\n"
    ]
   },
   {

--- a/notebooks/rank_analysis/notebooks/01 - building a dataset.ipynb
+++ b/notebooks/rank_analysis/notebooks/01 - building a dataset.ipynb
@@ -63,7 +63,7 @@
    "outputs": [],
    "source": [
     "resp = es.search(\n",
-    "    index=\"conversion\",\n",
+    "    index=\"metrics-conversion-prod\",\n",
     "    body={\n",
     "        \"query\": {\n",
     "            \"bool\": {\n",
@@ -87,7 +87,7 @@
     "    _source=[\"page.query.query\", \"properties.totalResults\", \"@timestamp\"],\n",
     "    size=100_000,\n",
     "    request_timeout=30,\n",
-    ")"
+    ")\n"
    ]
   },
   {


### PR DESCRIPTION
We're deprecating the use of the conversion index in favour of the new `metrics-conversion-prod` data stream ([more info about data streams here](https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html)).

NB we still need to reindex the historical data from the conversion index into the new data stream, so some of these instances where we're fetching data from a specific date range might not work seamlessly (yet).