### PR TITLE
Remove the deprecated template provider from the data-science repo

### DIFF
--- a/terraform/apis/.terraform.lock.hcl
+++ b/terraform/apis/.terraform.lock.hcl
@@ -7,10 +7,3 @@ provider "registry.terraform.io/hashicorp/aws" {
     "h1:oiX6JcoXY6lYIdcYWmEpr7mnS4mkyDV9intCNrcjiBs=",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/template" {
-  version = "2.2.0"
-  hashes = [
-    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
-  ]
-}

--- a/terraform/apis/main.tf
+++ b/terraform/apis/main.tf
@@ -20,7 +20,6 @@ module "palette_similarity" {
   nginx_container_port         = local.nginx_listener_port
   nginx_container_image        = local.nginx_container_image
   env_vars                     = {}
-  env_vars_length              = 0
   lb_arn                       = aws_lb.network_load_balancer.arn
   lb_dns_name                  = aws_lb.network_load_balancer.dns_name
   api_gateway_rest_api_id      = aws_api_gateway_rest_api.apis.id
@@ -56,7 +55,6 @@ module "feature_similarity" {
   nginx_container_port         = local.nginx_listener_port
   nginx_container_image        = local.nginx_container_image
   env_vars                     = {}
-  env_vars_length              = 0
   lb_arn                       = aws_lb.network_load_balancer.arn
   lb_dns_name                  = aws_lb.network_load_balancer.dns_name
   api_gateway_rest_api_id      = aws_api_gateway_rest_api.apis.id

--- a/terraform/apis/modules/ecs/modules/task/modules/container_definition/container_with_sidecar/main.tf
+++ b/terraform/apis/modules/ecs/modules/task/modules/container_definition/container_with_sidecar/main.tf
@@ -7,12 +7,9 @@ locals {
 
   app_container_name     = "app"
   sidecar_container_name = "sidecar"
-}
 
-data "template_file" "definition" {
-  template = file("${path.module}/task_definition.json.template")
-
-  vars = {
+  task_definition_template_path = "${path.module}/task_definition.json.template"
+  task_definition_template_vars = {
     log_group_region = var.aws_region
     log_group_prefix = var.log_group_prefix
 

--- a/terraform/apis/modules/ecs/modules/task/modules/container_definition/container_with_sidecar/main.tf
+++ b/terraform/apis/modules/ecs/modules/task/modules/container_definition/container_with_sidecar/main.tf
@@ -53,9 +53,8 @@ resource "aws_cloudwatch_log_group" "sidecar" {
 }
 
 module "sidecar_env_vars" {
-  source          = "../../env_vars"
-  env_vars        = var.sidecar_env_vars
-  env_vars_length = var.sidecar_env_vars_length
+  source   = "../../env_vars"
+  env_vars = var.sidecar_env_vars
 }
 
 # App
@@ -67,7 +66,6 @@ resource "aws_cloudwatch_log_group" "app" {
 }
 
 module "app_env_vars" {
-  source          = "../../env_vars"
-  env_vars        = var.app_env_vars
-  env_vars_length = var.app_env_vars_length
+  source   = "../../env_vars"
+  env_vars = var.app_env_vars
 }

--- a/terraform/apis/modules/ecs/modules/task/modules/container_definition/container_with_sidecar/outputs.tf
+++ b/terraform/apis/modules/ecs/modules/task/modules/container_definition/container_with_sidecar/outputs.tf
@@ -1,5 +1,8 @@
 output "rendered" {
-  value = data.template_file.definition.rendered
+  value = templatefile(
+    local.task_definition_template_path,
+    local.task_definition_template_vars
+  )
 }
 
 output "app_container_name" {

--- a/terraform/apis/modules/ecs/modules/task/modules/container_definition/container_with_sidecar/variables.tf
+++ b/terraform/apis/modules/ecs/modules/task/modules/container_definition/container_with_sidecar/variables.tf
@@ -29,10 +29,6 @@ variable "app_env_vars" {
   default     = {}
 }
 
-variable "sidecar_env_vars_length" {
-  default = 0
-}
-
 # Sidecar
 
 variable "sidecar_container_image" {}
@@ -53,8 +49,4 @@ variable "sidecar_env_vars" {
   description = "Environment variables to pass to the container"
   type        = map(string)
   default     = {}
-}
-
-variable "app_env_vars_length" {
-  default = 0
 }

--- a/terraform/apis/modules/ecs/modules/task/modules/env_vars/main.tf
+++ b/terraform/apis/modules/ecs/modules/task/modules/env_vars/main.tf
@@ -1,71 +1,14 @@
-# The AWS task definition format requires that you pass environment variables
-# as a list of objects in the form:
-#
-#     [
-#       {
-#         "name": "IP_ADDRESS",
-#         "value": "192.0.2.6"
-#       },
-#       ...
-#     ]
-#
-# This is very tedious and boring.  Asking downstream users to declare their
-# config variables as name/value pairs exposes this abstraction, so we have
-# to push the limits of Terraform's interpolation syntax to get this working.
-#
-# In a proper language, you can map over a list; something like:
-#
-#     >>> vars = {'IP_ADDRESS': '192.0.2.6', 'HOST': 'localhost'}
-#     >>> def to_name_val_pair(var_pair):
-#     ...     name, value = var_pair
-#     ...     return {'name': name, 'value': value}
-#     ...
-#     >>> map(to_name_val_pair, vars.items())
-#     [{'name': 'HOST', 'value': 'localhost'},
-#      {'name': 'IP_ADDRESS', 'value': '192.0.2.6'}]
-#
-# and then convert the result to JSON.  Unfortunately Terraform doesn't
-# (as far as I know?) give you a way to map over lists or maps that way, so
-# we get slightly creative.
-#
-# The template returns a single name-value pair, as a JSON dict:
-#
-#     {"name": "IP_ADDRESS", "value": "192.0.2.6"}
-#
-# Then we iterate that template over `local.env_vars`, which is a map
-# containing all our environment variables as key-value pairs, i.e.
-#
-#     env_vars = {
-#       IP_ADDRESS = "192.0.2.6"
-#       HOST       = "localhost"
-#     }
-#
-# rendering each of them as JSON dict.  Then we call join(", ", ...) on the
-# output to put them all in a list, and wrap that in square brackets.
-#
-# Based on "Using templates with count" in the Terraform interpolation syntax
-# docs: https://www.terraform.io/docs/configuration/interpolation.html
-
-data "template_file" "name_val_pair" {
-  // According to hashicorp/terraform#17287 and hashicorp/terraform#14677 length can only
-  // be calculated for not computed values. If a map or list contains computed values,
-  // the whole map is considered as computed.
-  //
-  // This means the way we pass environment variables at the moment only works if there
-  // are no computed values (i.e. outputs from modules or outputs
-  // from terraform resource types).
-  //
-  // TODO compute count once those issues are closed
-  count = var.env_vars_length
-
-  template = "{\"name\": $${jsonencode(key)}, \"value\": $${jsonencode(value)}}"
-
-  vars = {
-    key   = element(keys(var.env_vars), count.index)
-    value = element(values(var.env_vars), count.index)
-  }
+variable "env_vars" {
+  description = "Environment variables to pass to the container"
+  type        = map(string)
 }
 
-locals {
-  env_var_string = "[${join(", ", data.template_file.name_val_pair.*.rendered)}]"
+output "env_vars_string" {
+  value = jsonencode([
+    for key in keys(var.env_vars) :
+    {
+      name  = key
+      value = lookup(var.env_vars, key)
+    }
+  ])
 }

--- a/terraform/apis/modules/ecs/modules/task/modules/env_vars/outputs.tf
+++ b/terraform/apis/modules/ecs/modules/task/modules/env_vars/outputs.tf
@@ -1,3 +1,0 @@
-output "env_vars_string" {
-  value = local.env_var_string
-}

--- a/terraform/apis/modules/ecs/modules/task/modules/env_vars/variables.tf
+++ b/terraform/apis/modules/ecs/modules/task/modules/env_vars/variables.tf
@@ -1,6 +1,0 @@
-variable "env_vars" {
-  description = "Environment variables to pass to the container"
-  type        = map(string)
-}
-
-variable "env_vars_length" {}

--- a/terraform/apis/modules/ecs/modules/task/prebuilt/container_with_sidecar/main.tf
+++ b/terraform/apis/modules/ecs/modules/task/prebuilt/container_with_sidecar/main.tf
@@ -20,9 +20,6 @@ module "container_definition" {
   sidecar_container_image      = var.sidecar_container_image
   sidecar_port_mappings_string = module.sidecar_port_mappings.port_mappings_string
   sidecar_env_vars             = var.sidecar_env_vars
-
-  app_env_vars_length     = var.app_env_vars_length
-  sidecar_env_vars_length = var.sidecar_env_vars_length
 }
 
 module "task_definition" {

--- a/terraform/apis/modules/ecs/modules/task/prebuilt/container_with_sidecar/variables.tf
+++ b/terraform/apis/modules/ecs/modules/task/prebuilt/container_with_sidecar/variables.tf
@@ -32,14 +32,6 @@ variable "sidecar_env_vars" {
 
 variable "aws_region" {}
 
-variable "app_env_vars_length" {
-  default = 0
-}
-
-variable "sidecar_env_vars_length" {
-  default = 0
-}
-
 variable "launch_types" {
   type    = list(string)
   default = ["FARGATE", "EC2"]

--- a/terraform/apis/modules/service/api/main.tf
+++ b/terraform/apis/modules/service/api/main.tf
@@ -33,14 +33,10 @@ module "task" {
 
   app_env_vars = var.env_vars
 
-  app_env_vars_length = var.env_vars_length
-
   sidecar_env_vars = {
     APP_HOST = "localhost"
     APP_PORT = var.container_port
   }
-
-  sidecar_env_vars_length = "2"
 
   cpu    = var.cpu
   memory = var.memory

--- a/terraform/apis/modules/service/api/variables.tf
+++ b/terraform/apis/modules/service/api/variables.tf
@@ -22,8 +22,6 @@ variable "security_group_ids" {
   type = list(string)
 }
 
-variable "env_vars_length" {}
-
 variable "env_vars" {
   type = map(string)
 }

--- a/terraform/apis/terraform.tf
+++ b/terraform/apis/terraform.tf
@@ -30,5 +30,3 @@ provider "aws" {
 
   region = "eu-west-1"
 }
-
-provider "template" {}


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5557

It'd be nice if we could get the data-science repo using the pre-packaged modules, but in the meantime I've copy/pasted the newest bits to get rid of some of the hacky JSON templating logic.