### PR TITLE
Upgrade to v4.x of the AWS Terraform provider

### DIFF
--- a/terraform/apis/.terraform.lock.hcl
+++ b/terraform/apis/.terraform.lock.hcl
@@ -2,8 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "3.47.0"
+  version = "4.58.0"
   hashes = [
-    "h1:oiX6JcoXY6lYIdcYWmEpr7mnS4mkyDV9intCNrcjiBs=",
+    "h1:znLROwEAINbYzAG5X7Ep04whM7KxkQGrvhFdhSvNKEk=",
   ]
 }


### PR DESCRIPTION
No deprecation warnings; nothing to change.

For https://github.com/wellcomecollection/platform/issues/5664