### PR TITLE
make requirements for installing weco-datascience less strict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,20 +12,20 @@ description-file = "weco_datascience/README.md"
 classifiers = ["License :: OSI Approved :: MIT License"]
 requires-python = ">=3.6"
 requires = [
-    "aiofile==3.1.0",
-    "aiohttp[speedups]==3.6.2",
-    "async-timeout==3.0.1",
-    "boto3==1.12.14",
-    "Pillow==7.0.0",
-    "piffle==0.3.0",
-    "urlpath==1.1.7",
-    "elasticsearch==7.14",
+    "aiofile>=3.1.0",
+    "aiohttp[speedups]>=3.6.2",
+    "async-timeout>=3.0.1",
+    "boto3>=1.12.14",
+    "Pillow>=7.0.0",
+    "piffle>=0.3.0",
+    "urlpath>=1.1.7",
+    "elasticsearch>=7.14,<8",
 ]
 
 [tool.flit.metadata.requires-extra]
 dev = [
-    "black==19.10b0",
-    "flake8==3.8.1",
-    "isort==4.3.21",
-    "pytest-asyncio==0.14.0",
+    "black>=19.10b0",
+    "flake8>=3.8.1",
+    "isort>=4.3.21",
+    "pytest-asyncio>=0.14.0",
 ]

--- a/weco_datascience/__init__.py
+++ b/weco_datascience/__init__.py
@@ -2,4 +2,4 @@
 Common functionality for data science applications at Wellcome Collection
 """
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"


### PR DESCRIPTION
Creating a new release for `weco-datascience` with less-strict requirements, so that it can be installed by the new version of the `color_inferrer`