### PR TITLE
piffle.iiif is now piffle.image

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ requires = [
     "async-timeout>=3.0.1",
     "boto3>=1.12.14",
     "Pillow>=7.0.0",
-    "piffle>=0.3.0",
+    "piffle>=0.5.0",
     "urlpath>=1.1.7",
     "elasticsearch>=7.14,<8",
 ]

--- a/scripts/download_images/main.py
+++ b/scripts/download_images/main.py
@@ -3,7 +3,7 @@ import json
 import shutil
 from pathlib import Path
 
-from piffle.iiif import IIIFImageClient
+from piffle.image import IIIFImageClient
 import httpx
 from tqdm import tqdm
 

--- a/weco_datascience/image.py
+++ b/weco_datascience/image.py
@@ -2,7 +2,7 @@ from io import BytesIO
 from urllib.parse import unquote_plus, urlparse
 
 from aiofile import AIOFile
-from piffle.iiif import IIIFImageClient, ParseError
+from piffle.image import IIIFImageClient, ParseError
 from PIL import Image, UnidentifiedImageError
 
 from .http import fetch_url_bytes


### PR DESCRIPTION
## What does this change?

[An earlier change](https://github.com/wellcomecollection/data-science/commit/11c1d7eff279dfaed005a34509f06f85b6a7fa1d) made it possible to install Piffle 0.5.0 (>=0.3.0) alongside `weco-datascience`.  

[Piffle 0.4.0](https://github.com/Princeton-CDH/piffle/releases/tag/0.4) renamed `piffle.iiif` to `piffle.image`.

This means that it was possible to create a non-working combination of libraries when installing `weco-datascience`


## How to test

Running the application in any way will show that the new version of piffle is compatible with the code in this application

## How can we measure success?

I made this change as part of Critical Vulnerability work.  It is not a vulnerability itself, but the mismatch between the code and the version was causing build errors in the [pipeline inferrers](https://github.com/wellcomecollection/catalogue-pipeline/tree/main/pipeline/inferrer) when I tried to upgrade them.

This should facilitate some further upgrades to dependencies.

## Have we considered potential risks?

`weco-datascience` is only used in [one place outside of this repository](https://github.com/wellcomecollection/catalogue-pipeline/tree/main/pipeline/inferrer), so it shouldn't be problematic.

piffle is only used inside `weco-datascience` 

A similar problem exists in the [mozfest notebooks ](https://github.com/wellcomecollection/mozfest), but that is a read-only archive, so I'm not changing it and I will leave it as something exciting for whoever eventually decides to use them.
