### PR TITLE
only use versions of Pillow past the current known vulnerability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,13 @@ author-email = "h.pim@wellcome.ac.uk"
 home-page = "https://github.com/wellcomecollection/data-science"
 description-file = "weco_datascience/README.md"
 classifiers = ["License :: OSI Approved :: MIT License"]
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 requires = [
     "aiofile>=3.1.0",
     "aiohttp[speedups]>=3.6.2",
     "async-timeout>=3.0.1",
     "boto3>=1.12.14",
-    "Pillow>=7.0.0",
+    "Pillow>=10.3.0",
     "piffle>=0.5.0",
     "urlpath>=1.1.7",
     "elasticsearch>=7.14,<8",


### PR DESCRIPTION
## What does this change?

Upgrade Pillow to `10.3.0`, as recommended by [Dependabot](https://github.com/wellcomecollection/catalogue-pipeline/security/dependabot/129).

Upgrading Pillow to this version requires at least Python 3.8

## How to test
```
make setup
make build
```
## How can we measure success?

When this version of `weco-datascience` is used in the catalogue pipeline inferrer, it will reduce the [Dependabot warnings](https://github.com/wellcomecollection/catalogue-pipeline/security/dependabot)

## Have we considered potential risks?

The applications that use this library mostly use python 3.7 (which is past EoL, so they need to be upgraded).  This might make it a bit tricky to implement.  However, as I have to do this anyway, I don't think that's a risk added by this change.

