### PR TITLE
Upgrade aiofile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description-file = "weco_datascience/README.md"
 classifiers = ["License :: OSI Approved :: MIT License"]
 requires-python = ">=3.6"
 requires = [
-    "aiofile>=3.1.0",
+    "aiofile>=3.8.8",
     "aiohttp[speedups]>=3.6.2",
     "async-timeout>=3.0.1",
     "boto3>=1.12.14",


### PR DESCRIPTION
## What does this change?

Upgrade aiofile to the latest version.

`aiofile` brings with it `caio`.  The version of `caio~=0.6.0` associated with the `aiofile==3.1.0` will not install on python 3.8 or later.

## How to test

```
make setup
make build
```

## How can we measure success?

This will make it easier to upgrade to later versions of Python in order to upgrade vulnerable dependencies.
