### PR TITLE
add build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,14 @@
 # When a new release is created in the data-science repo, the weco-datascience
 # package is built and released with flit, using the same tag.
 
-name: Publish to pypi with flit
+name: Build weco_datascience
 
 on:
   pull_request:
     paths:
       - weco_datascience/**
       - pyproject.toml
+      - Makefile
 
 jobs:
   deploy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.10"
       - name: Install dependencies
         run: make setup
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.x"
       - name: Install dependencies
         run: make setup
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+# When a new release is created in the data-science repo, the weco-datascience
+# package is built and released with flit, using the same tag.
+
+name: Publish to pypi with flit
+
+on:
+  pull_request:
+    paths:
+      - weco_datascience/**
+      - pyproject.toml
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: make setup
+      - name: Build
+        run: make build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.x"
+          python-version: "3.10"
       - name: Install dependencies
         run: make setup
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
       - Makefile
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.x"
+          python-version: "3.10"
       - name: Install dependencies
         run: make setup
       - name: Build and publish

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,11 @@ lint:
 test:
 	python -m pytest ./weco_datascience/test
 
-build: clean lint test
+show_versions:
 	python --version
 	pip freeze
+
+build: show_versions clean lint test
 	flit build
 
 

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ test:
 	python -m pytest ./weco_datascience/test
 
 build: clean lint test
-    python --version
-    pip freeze
+	python --version
+	pip freeze
 	flit build
 
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ test:
 	python -m pytest ./weco_datascience/test
 
 build: clean lint test
+    python --version
+    pip freeze
 	flit build
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ build-backend = "flit_core.buildapi"
 module = "weco_datascience"
 dist-name = "weco-datascience"
 author = "Harrison Pim"
-author-email = "h.pim@wellcome.ac.uk"
 home-page = "https://github.com/wellcomecollection/data-science"
 description-file = "weco_datascience/README.md"
 classifiers = ["License :: OSI Approved :: MIT License"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ author = "Harrison Pim"
 home-page = "https://github.com/wellcomecollection/data-science"
 description-file = "weco_datascience/README.md"
 classifiers = ["License :: OSI Approved :: MIT License"]
-requires-python = ">=3.8"
+requires-python = ">=3.8,<3.11"
 requires = [
     "aiofile>=3.8.8",
-    "aiohttp[speedups]>=3.6.2",
+    "aiohttp[speedups]>=3.9.5",
     "async-timeout>=3.0.1",
     "boto3>=1.12.14",
     "Pillow>=10.3.0",

--- a/weco_datascience/reporting.py
+++ b/weco_datascience/reporting.py
@@ -64,7 +64,11 @@ def query_es(config, index, query):
 
 
 def get_data_in_date_range(
-    config, index, start_date="now-1d", end_date="now", timestamp_field="@timestamp"
+    config,
+    index,
+    start_date="now-1d",
+    end_date="now",
+    timestamp_field="@timestamp",
 ):
     """
     Fetch data within a specified date/time range
@@ -135,15 +139,13 @@ def get_es_config():
     )
 
     config = {
-        "host": get_secret_string(
-            session, secret_id="reporting/es_host"
-        ),
+        "host": get_secret_string(session, secret_id="reporting/es_host"),
         "username": get_secret_string(
             session, secret_id="reporting/read_only/es_username"
         ),
         "password": get_secret_string(
             session, secret_id="reporting/read_only/es_password"
-        )
+        ),
     }
     return config
 


### PR DESCRIPTION
## What does this change?

This adds a build action, triggered on PRs that would include changes the weco_datascience python library.

It also pins the build and existing publish jobs to use Python 3.10.  This is the latest version that works with the given collection of dependencies (urlpath has no 3.12-compatible version yet, 3.11 needs some `certifi` changes that are a bit more involved than I want to go into right now)

## How to test

Open a PR, watch it happen.

## How can we measure success?

No surprise build failures when we create releases
